### PR TITLE
Splitted Mailer for Laravel 7 and previous versions

### DIFF
--- a/src/HeloLaravelServiceProvider.php
+++ b/src/HeloLaravelServiceProvider.php
@@ -45,7 +45,6 @@ class HeloLaravelServiceProvider extends ServiceProvider
             ], 'config');
         }
 
-        
         $this->mergeConfigFrom(__DIR__.'/../config/helo.php', 'helo');
 
         $this->app->singleton(Mailer::class, function ($app) {
@@ -93,7 +92,7 @@ class HeloLaravelServiceProvider extends ServiceProvider
         // Once we have create the mailer instance, we will set a container instance
         // on the mailer. This allows us to resolve mailer classes via containers
         // for maximum testability on said classes instead of passing Closures.
-        $mailer = new Mailer(
+        $mailer = new Laravel7Mailer(
             'smtp', $app['view'], $swiftMailer, $app['events']
         );
 

--- a/src/Laravel7Mailer.php
+++ b/src/Laravel7Mailer.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace BeyondCode\HeloLaravel;
+
+use Illuminate\Contracts\Mail\Factory as MailFactory;
+use Illuminate\Contracts\Mail\Mailer as MailerContract;
+
+class Laravel7Mailer extends Mailer implements MailerContract, MailFactory
+{
+    public function mailer($name = null)
+    {
+        $this->currentMailer = $name;
+
+        return $this;
+    }
+}

--- a/tests/HeloTest.php
+++ b/tests/HeloTest.php
@@ -3,6 +3,8 @@
 namespace BeyondCode\HeloLaravel\Tests;
 
 use BeyondCode\HeloLaravel\HeloLaravelServiceProvider;
+use BeyondCode\HeloLaravel\Mailer;
+use BeyondCode\HeloLaravel\Laravel7Mailer;
 use BeyondCode\HeloLaravel\TestMail;
 use BeyondCode\HeloLaravel\TestMailCommand;
 use Illuminate\Support\Facades\Mail;
@@ -10,7 +12,7 @@ use Orchestra\Testbench\TestCase;
 
 class HeloTest extends TestCase
 {
-    protected function getPackageProviders()
+    protected function getPackageProviders($app)
     {
         return [
             HeloLaravelServiceProvider::class
@@ -25,5 +27,17 @@ class HeloTest extends TestCase
         $this->artisan(TestMailCommand::class);
 
         Mail::assertSent(TestMail::class);
+    }
+
+    /** @test */
+    public function test_the_correct_mailer_is_binded()
+    {
+        $mailer = app(Mailer::class);
+
+        if (version_compare(app()->version(), '7.0.0', '<')) {
+            $this->assertTrue($mailer instanceof Mailer);
+        } else {
+            $this->assertTrue($mailer instanceof Laravel7Mailer);
+        }
     }
 }


### PR DESCRIPTION
Fixes #1 

@mpociot when I suggested using SwiftMailer plugins I still hadn't see the inner workings of the plugin. Since it's tied to the `Mailable`, it's difficult to implement as a SwiftMailer plugin and provides no advantages.

I think the fix in this PR solves the problem in the easiest way possible. I just split the Mailers and added the same `mailer` method that is found in the `MailFake` class.