### PR TITLE
Fix: Laravel7Mailer::extend does not exist.

### DIFF
--- a/src/Laravel7Mailer.php
+++ b/src/Laravel7Mailer.php
@@ -13,4 +13,13 @@ class Laravel7Mailer extends Mailer implements MailerContract, MailFactory
 
         return $this;
     }
+    
+     /**
+     * Void function, bug fix for BeyondCode Hello
+     * Github issue: https://github.com/beyondcode/helo-laravel/issues/15
+     */
+    public static function extend()
+    {
+
+    }
 }


### PR DESCRIPTION
Adding void function for error:  Method BeyondCode\HeloLaravel\Laravel7Mailer::extend does not exist.