### PR TITLE
Updated Service Provider to not register the Mailer if tests are running

### DIFF
--- a/src/HeloLaravelServiceProvider.php
+++ b/src/HeloLaravelServiceProvider.php
@@ -17,7 +17,7 @@ class HeloLaravelServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        if (!$this->app['config']['helo.is_enabled']) {
+        if ($this->app->runningUnitTests() || !$this->app['config']['helo.is_enabled']) {
             return;
         }
 


### PR DESCRIPTION
I recently had an issue where some tests were failing that used the Mail::fake() and Mail::assert...() methods.

Rather than using the Mail facade or anything in the controller I was injecting `Illuminate\Contracts\Mail\Mailer`and then using that to send my emails. After a lot of debugging I found that when I was using `dd()` in the controller on the Mailer variable while running the failing test, it was actually an instance of the Helo Mailer rather than the MailFake I was expecting.

I fixed this by updating my phpunit.xml to set the `HELO_ENABLED` env variable to `false`. At first, it wasn't immediately obvious that Helo was causing the issue and that I could stop the Helo Mailer getting instantiated by adding the variable, which is why I created this PR just to update the Service Provider to return early if `$this->app->runningUnitTests()` is `true` for anyone else that runs into this issue and to save a couple of hours of trying to figure out why!