### PR TITLE
Move adding view namespace to boot method

### DIFF
--- a/src/HeloLaravelServiceProvider.php
+++ b/src/HeloLaravelServiceProvider.php
@@ -26,6 +26,10 @@ class HeloLaravelServiceProvider extends ServiceProvider
         Mail::swap($instance);
 
         app()->instance(MailerContract::class, $instance);
+        
+        if ($this->app->runningInConsole()) {
+            View::addNamespace('helo', __DIR__ . '/../resources/views');
+        }
     }
 
     /**
@@ -37,9 +41,7 @@ class HeloLaravelServiceProvider extends ServiceProvider
             $this->commands([
                 TestMailCommand::class,
             ]);
-
-            View::addNamespace('helo', __DIR__ . '/../resources/views');
-
+            
             $this->publishes([
                 __DIR__.'/../config/helo.php' => base_path('config/helo.php'),
             ], 'config');


### PR DESCRIPTION
Calling `View::` in the register method resolves the View Factory very early in the registering process. I've ran into an issue in which the View is resolved earlier some the other service providers are registered

Relevant packages: blade-icons, heroicons and zondicons.

Because of the `View::addNamespace` call in Helo service provider, zondicons register method is called after the view is resolved.  

By moving the addNamespace call to the boot method, this issue is resolved and should work exactly the same I believe.