### PR TITLE
Allow For PHP 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 docs
 vendor
 coverage
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 7.3
   - 7.4
+  - 8.0
 
 env:
   matrix:

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,14 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "illuminate/view": "^6.0|^7.0|^8.0",
         "illuminate/console": "^6.0|^7.0|^8.0",
         "illuminate/mail": "^6.0|^7.0|^8.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.1",
-        "phpunit/phpunit": "^8.0"
+        "orchestra/testbench": "^5.1 | ^6.3",
+        "phpunit/phpunit": "^8.0 | ^9.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This is same as #25 because I do not have access to update that PR and it seems stale.

The following PR allows for `helo-laravel` to be installed with PHP 8 applications 