### PR TITLE
Prevents crash on Laravel 9 when using `\Mail::extend()`

### DIFF
--- a/src/Laravel7Mailer.php
+++ b/src/Laravel7Mailer.php
@@ -13,4 +13,9 @@ class Laravel7Mailer extends Mailer implements MailerContract, MailFactory
 
         return $this;
     }
+    
+    public function extend()
+    {
+        //
+    }
 }


### PR DESCRIPTION
Using this package with Laravel 9, it is not possible to use `\Mail::extend()`.

This little change adds an empty `extend()` method to Laravel7Mailer to prevent it from crashing.