### PR TITLE
use Swift_Mailer to fix namespace error

### DIFF
--- a/src/CreatesMailers.php
+++ b/src/CreatesMailers.php
@@ -4,6 +4,7 @@ namespace BeyondCode\HeloLaravel;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Swift_Mailer;
 
 trait CreatesMailers
 {


### PR DESCRIPTION
When doing a composer update, the following error occurs, as also stated in #40 :
```
> @php artisan package:discover --ansi

   Error 
  Class "BeyondCode\HeloLaravel\Swift_Mailer" not found

  at vendor/beyondcode/helo-laravel/src/CreatesMailers.php:41
     37▕         $defaultDriver = $app['mail.manager']->getDefaultDriver();
     38▕         $config = $this->getConfig($defaultDriver);
     39▕ 
     40▕         // Laravel 7 no longer bindes the swift.mailer:
  ➜  41▕         $swiftMailer = new Swift_Mailer($app['mail.manager']->createTransport($config));
     42▕ 
     43▕         // Once we have create the mailer instance, we will set a container instance
     44▕         // on the mailer. This allows us to resolve mailer classes via containers
     45▕         // for maximum testability on said classes instead of passing Closures.

      +15 vendor frames 
  16  [internal]:0
      Illuminate\Foundation\Application::Illuminate\Foundation\{closure}(Object(BeyondCode\HeloLaravel\HeloLaravelServiceProvider))

      +5 vendor frames 
  22  artisan:37
      Illuminate\Foundation\Console\Kernel::handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
Script @php artisan package:discover --ansi handling the post-autoload-dump event returned with error code 1
```

I could reproduce this and narrowed it down to a missing use of the SwiftMailer package, which was newed up without explicitly calling the complete class name. The use fixes that for me.