### PR TITLE
Fix Laravel 10 support with xdebug installed

### DIFF
--- a/src/CreatesMailers.php
+++ b/src/CreatesMailers.php
@@ -68,7 +68,11 @@ trait CreatesMailers
         $config = $this->getConfig($defaultDriver);
 
         // We get Symfony Transport from Laravel 9 mailer
-        $symfonyTransport = $app['mail.manager']->getSymfonyTransport();
+        if (version_compare(app()->version(), '10.0.0', '<')) {
+            $symfonyTransport = $app['mail.manager']->getSymfonyTransport();
+        } else {
+            $symfonyTransport = $app['mailer']->getSymfonyTransport();
+        }
 
         // Once we have create the mailer instance, we will set a container instance
         // on the mailer. This allows us to resolve mailer classes via containers


### PR DESCRIPTION
In a vanilla Laravel 10 install this package errors if you have xdebug installed, as seen in https://github.com/beyondcode/helo-laravel/issues/42

Adding a version_compare check to change the symfony transport if you're using Laravel 9 vs 10 allows the extension to work in the latest versions of Laravel 10.